### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/ecowater_softener/sensor.py
+++ b/custom_components/ecowater_softener/sensor.py
@@ -50,8 +50,6 @@ SENSOR_TYPES: tuple[EcowaterSensorEntityDescription, ...] = (
         key=WATER_AVAILABLE,
         name="Water Available",
         icon="mdi:water",
-        device_class=SensorDeviceClass.WATER,
-        state_class=SensorStateClass.MEASUREMENT,
     ),
     EcowaterSensorEntityDescription(
         key=WATER_USAGE_TODAY,


### PR DESCRIPTION
According to the new HA update to 2023.2 … there is an error at log.

The log is showing entity “water_available” has device class as “water” and “water” cannot have “measure” as state class.

> Logger: homeassistant.components.sensor
> Source: components/sensor/__init__.py:503 
> Integration: Sensor (documentation, issues) 
> First occurred: 08:14:16 (1 occurrences) 
> Last logged: 08:14:16
> 
> Entity sensor.ecowater_xxxxxxxxxxxxxxx_water_available (<class 'custom_components.ecowater_softener.sensor.EcowaterSensor'>) is using state class 'measurement' which is impossible considering device class ('water') it is using; Please update your configuration if your entity is manually configured, otherwise report it to the custom integration author.

This warning it is shown at HA restarts.

So removing device _class and state_class for the key=WATER_AVAILABLE could be a temporary solution.