### PR TITLE
Fix manifest.json ordering

### DIFF
--- a/custom_components/ecowater_softener/manifest.json
+++ b/custom_components/ecowater_softener/manifest.json
@@ -1,12 +1,12 @@
 {
+  "domain": "ecowater_softener",
+  "name": "Ecowater Softener",
   "codeowners": ["@barleybobs"],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/barleybobs/homeassistant-ecowater-softener/",
-  "issue_tracker": "https://github.com/barleybobs/homeassistant-ecowater-softener/issues",
-  "domain": "ecowater_softener",
-  "name": "Ecowater Softener",
-  "requirements": ["ecowater-softener==1.0.0"],
   "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/barleybobs/homeassistant-ecowater-softener/issues",
+  "requirements": ["ecowater-softener==1.0.0"],
   "version": "3.0.0"
 }


### PR DESCRIPTION
To make it pass hassfest validation, the keys need to be domain, then name, then the rest of the keys in alphabetical order.