### PR TITLE
adding support for no-salt systems and flow rate

### DIFF
--- a/custom_components/ecowater_softener/config_flow.py
+++ b/custom_components/ecowater_softener/config_flow.py
@@ -14,7 +14,8 @@ DATA_SCHEMA_USER = vol.Schema(
         vol.Required("username"): str,
         vol.Required("password"): str,
         vol.Required("serialnumber"): str,
-        vol.Required("dateformat"): vol.In(['dd/mm/yyyy', 'mm/dd/yyyy'])
+        vol.Required("dateformat"): vol.In(['dd/mm/yyyy', 'mm/dd/yyyy']),
+        vol.Required("usessalt", default=True): bool
     }
 )
 

--- a/custom_components/ecowater_softener/const.py
+++ b/custom_components/ecowater_softener/const.py
@@ -10,3 +10,4 @@ WATER_AVAILABLE = "water_available"
 WATER_UNITS = "water_units"
 RECHARGE_ENABLED = "recharge_enabled"
 RECHARGE_SCHEDULED = "recharge_scheduled"
+WATER_FLOW ='water_flow'

--- a/custom_components/ecowater_softener/coordinator.py
+++ b/custom_components/ecowater_softener/coordinator.py
@@ -17,6 +17,7 @@ from .const import (
     WATER_UNITS,
     RECHARGE_ENABLED,
     RECHARGE_SCHEDULED,
+    WATER_FLOW
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,18 +25,19 @@ _LOGGER = logging.getLogger(__name__)
 class EcowaterDataCoordinator(DataUpdateCoordinator):
     """Class to manage fetching Ecowater data."""
 
-    def __init__(self, hass, username, password, serialnumber, dateformat):
+    def __init__(self, hass, username, password, serialnumber, dateformat, usessalt):
         """Initialize Ecowater coordinator."""
         super().__init__(
             hass,
             _LOGGER,
             name="Ecowater " + serialnumber,
-            update_interval=timedelta(minutes=10),
+            update_interval=timedelta(minutes=1),
         )
         self._username = username
         self._password = password
         self._serialnumber = serialnumber
         self._dateformat = dateformat
+        self._usessalt = usessalt
 
     async def _async_update_data(self):
         """Fetch data from API endpoint.
@@ -48,35 +50,43 @@ class EcowaterDataCoordinator(DataUpdateCoordinator):
 
             ecowaterDevice = Ecowater(self._username, self._password, self._serialnumber)
             data_json = await self.hass.async_add_executor_job(lambda: ecowaterDevice._get())
-
+            
             nextRecharge_re = "device-info-nextRecharge'\)\.html\('(?P<nextRecharge>.*)'"
 
             data[STATUS] = 'Online' if data_json['online'] == True else 'Offline'
-            data[DAYS_UNTIL_OUT_OF_SALT] = data_json['out_of_salt_days']
 
-            # Checks if date is 'today' or 'tomorrow'
-            if str(data_json['out_of_salt']).lower() == 'today':
-                data[OUT_OF_SALT_ON] = datetime.today().strftime('%Y-%m-%d')
-            elif str(data_json['out_of_salt']).lower() == 'tomorrow':
-                data[OUT_OF_SALT_ON] = (datetime.today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')
-            # Runs correct datetime.strptime() depending on date format entered during setup.
-            elif self._dateformat == "dd/mm/yyyy":
-                data[OUT_OF_SALT_ON] = datetime.strptime(data_json['out_of_salt'], '%d/%m/%Y').strftime('%Y-%m-%d')
-            elif self._dateformat == "mm/dd/yyyy":
-                data[OUT_OF_SALT_ON] = datetime.strptime(data_json['out_of_salt'], '%m/%d/%Y').strftime('%Y-%m-%d')
+            # Skip salt calculations for non-salt equipment
+            if self._usessalt is True:
+                # Salt
+                data[DAYS_UNTIL_OUT_OF_SALT] = data_json['out_of_salt_days']
+                # Checks if date is 'today' or 'tomorrow'
+                if str(data_json['out_of_salt']).lower() == 'today':
+                    data[OUT_OF_SALT_ON] = datetime.today().strftime('%Y-%m-%d')
+                elif str(data_json['out_of_salt']).lower() == 'tomorrow':
+                    data[OUT_OF_SALT_ON] = (datetime.today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')
+                # Runs correct datetime.strptime() depending on date format entered during setup.
+                elif self._dateformat == "dd/mm/yyyy":
+                    data[OUT_OF_SALT_ON] = datetime.strptime(data_json['out_of_salt'], '%d/%m/%Y').strftime('%Y-%m-%d')
+                elif self._dateformat == "mm/dd/yyyy":
+                    data[OUT_OF_SALT_ON] = datetime.strptime(data_json['out_of_salt'], '%m/%d/%Y').strftime('%Y-%m-%d')
+                else:
+                    data[OUT_OF_SALT_ON] = ''
+                    _LOGGER.exception(
+                        f"Error: Date format not set"
+                    )
+                data[SALT_LEVEL_PERCENTAGE] = data_json['salt_level_percent']
             else:
+                data[SALT_LEVEL_PERCENTAGE] = 0
                 data[OUT_OF_SALT_ON] = ''
-                _LOGGER.exception(
-                    f"Error: Date format not set"
-                )
-
-            data[SALT_LEVEL_PERCENTAGE] = data_json['salt_level_percent']
+                data[DAYS_UNTIL_OUT_OF_SALT] = 0
+                
             data[WATER_USAGE_TODAY] = data_json['water_today']
             data[WATER_USAGE_DAILY_AVERAGE] = data_json['water_avg']
             data[WATER_AVAILABLE] = data_json['water_avail']
             data[WATER_UNITS] = str(data_json['water_units'])
             data[RECHARGE_ENABLED] = data_json['rechargeEnabled']
             data[RECHARGE_SCHEDULED] = False if ( re.search(nextRecharge_re, data_json['recharge']) ).group('nextRecharge') == 'Not Scheduled' else True
+            data[WATER_FLOW] = data_json['water_flow']
             
             return data
         except Exception as e:

--- a/custom_components/ecowater_softener/sensor.py
+++ b/custom_components/ecowater_softener/sensor.py
@@ -13,11 +13,11 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
 from homeassistant.const import (
-    VOLUME_LITERS,
-    VOLUME_GALLONS,
-    TIME_DAYS,
     PERCENTAGE,
+    UnitOfTime,
+    UnitOfVolume
 )
 
 from .const import (
@@ -31,6 +31,7 @@ from .const import (
     WATER_AVAILABLE,
     RECHARGE_ENABLED,
     RECHARGE_SCHEDULED,
+    WATER_FLOW
 )
 
 
@@ -80,7 +81,7 @@ SENSOR_TYPES: tuple[EcowaterSensorEntityDescription, ...] = (
         key=DAYS_UNTIL_OUT_OF_SALT,
         name="Days until out of salt",
         icon="mdi:calendar",
-        native_unit_of_measurement=TIME_DAYS,
+        native_unit_of_measurement=UnitOfTime.DAYS,
     ),
     EcowaterSensorEntityDescription(
         key=RECHARGE_ENABLED,
@@ -89,6 +90,11 @@ SENSOR_TYPES: tuple[EcowaterSensorEntityDescription, ...] = (
     EcowaterSensorEntityDescription(
         key=RECHARGE_SCHEDULED,
         name="Recharged scheduled",
+    ),
+    EcowaterSensorEntityDescription(
+        key=WATER_FLOW,
+        name="Water Flow (from API)",
+        icon="mdi:water",
     ),
 )
 
@@ -102,7 +108,7 @@ async def async_setup_entry(
     if config_entry.options:
         config.update(config_entry.options)
 
-    coordinator = EcowaterDataCoordinator(hass, config['username'], config['password'], config['serialnumber'], config['dateformat']) 
+    coordinator = EcowaterDataCoordinator(hass, config['username'], config['password'], config['serialnumber'], config['dateformat'], config['usessalt']) 
 
     await coordinator.async_config_entry_first_refresh()
 
@@ -137,9 +143,9 @@ class EcowaterSensor(
     def native_unit_of_measurement(self) -> StateType:
         if self.entity_description.key.startswith('water'):
             if self.coordinator.data['water_units'].lower() == 'liters':
-                return VOLUME_LITERS
+                return UnitOfVolume.LITERS
             elif self.coordinator.data['water_units'].lower() == 'gallons':
-                return VOLUME_GALLONS
+                return UnitOfVolume.GALLONS
         elif self.entity_description.native_unit_of_measurement != None:
             return self.entity_description.native_unit_of_measurement
 


### PR DESCRIPTION
- increasing check frequency to 1 minute
- adding flow rate from api
- adding support for no salt (oxidizing, etc) systems
- fixing deprecated unit warnings

i have an oxidation iron filter system that does not use salt but does backwash nightly

the api shows daily usage, average usage, flow rate, and several other stats. integration was working until recent update, which broke because the salt values were not being found. this change adds a checkbox "Uses Salt" to integration configuration, which can be turned off for systems which do not use salt. There are several other ecowater systems which are either plain filters or other types which do not use salt, this should work for those as well