### PR TITLE
Update coordinator.py

### DIFF
--- a/custom_components/ecowater_softener/coordinator.py
+++ b/custom_components/ecowater_softener/coordinator.py
@@ -49,7 +49,7 @@ class EcowaterDataCoordinator(DataUpdateCoordinator):
             ecowaterDevice = Ecowater(self._username, self._password, self._serialnumber)
             data_json = await self.hass.async_add_executor_job(lambda: ecowaterDevice._get())
 
-            nextRecharge_re = "device-info-nextRecharge'\)\.html\('(?P<nextRecharge>.*)'"
+            nextRecharge_re = "device-info-nextRecharge')\.html\('(?P<nextRecharge>.*)'"
 
             data[STATUS] = 'Online' if data_json['online'] == True else 'Offline'
             data[DAYS_UNTIL_OUT_OF_SALT] = data_json['out_of_salt_days']


### PR DESCRIPTION
After restarting Home Assistant I found the following error at log.

> Logger: py.warnings
> Source: custom_components/ecowater_softener/sensor.py:36
> Integration: Ecowater Softener (documentation, issues)
> First occurred: 19:05:26 (1 occurrences)
> Last logged: 19:05:26
> 
> /config/custom_components/ecowater_softener/coordinator.py:52: SyntaxWarning: invalid escape sequence '\)' nextRecharge_re = "device-info-nextRecharge'\)\.html\('(?P<nextRecharge>.*)'"

I tested the change in my own installation and seems to work Ok. The error disappeared after the restart of HA.

