### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/ecowater_softener/__init__.py
+++ b/custom_components/ecowater_softener/__init__.py
@@ -22,9 +22,8 @@ async def async_setup_entry(
     hass.data[DOMAIN][entry.entry_id] = hass_data
 
     # Forward the setup to the sensor platform.
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "sensor")
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
+    
     return True
 
 


### PR DESCRIPTION
Update __init__.py file to solve log warning:

"Detected that custom integration 'ecowater_softener' calls async_forward_entry_setup for integration, ecowater_softener with title: Ecowater "serial number" and entry_id: xxxxxxxxxxxxxxxxxxx, which is deprecated and will stop working in Home Assistant 2025.6, await async_forward_entry_setups instead at custom_components/ecowater_softener/__init__.py, line 25: await hass.config_entries.async_forward_entry_setup(entry, "sensor"), please create a bug report at https://github.com/barleybobs/homeassistant-ecowater-softener/issues"